### PR TITLE
Vendor prefixes

### DIFF
--- a/demo.css
+++ b/demo.css
@@ -22,11 +22,7 @@ h1 {
 
 .small-grid li,
 .item-grid li {
-  -moz-border-radius: 10px;
-  -webkit-border-radius: 10px;
   border-radius: 10px;
-  -moz-box-shadow: -1px 1px 2px 1px rgba(0, 0, 0, 0.2);
-  -webkit-box-shadow: -1px 1px 2px 1px rgba(0, 0, 0, 0.2);
   box-shadow: -1px 1px 2px 1px rgba(0, 0, 0, 0.2);
   background-color: #666;
   height: 200px;


### PR DESCRIPTION
I merely removed the -moz- and -webkit- prefixes for border-radius and box-shadow because they are no longer needed for Firefox v4.0 or greater and Chrome v10.0 or greater.
Current version of Firefox is 19.0
Current version of Chrome is 25.0

Sources:
http://caniuse.com/#feat=border-radius
http://caniuse.com/#feat=css-boxshadow
